### PR TITLE
fix crash on python 3.14 `except` blocks that contain multiple exceptions with no parentheses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,21 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "annotate-snippets"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,15 +141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,10 +167,7 @@ version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -208,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -233,12 +206,6 @@ dependencies = [
  "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -651,29 +618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +868,35 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3590fea8e9e22d449600c9bbd481a8163bef223e4ff938e5f55899f8cf1adb93"
+dependencies = [
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -1282,7 +1255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1311,6 +1284,15 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1454,8 +1436,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1465,7 +1457,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1475,6 +1477,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -1616,7 +1627,7 @@ dependencies = [
 [[package]]
 name = "ruff_annotate_snippets"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "anstyle",
  "memchr",
@@ -1626,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "ruff_cache"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "filetime",
  "glob",
@@ -1639,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "ruff_diagnostics"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "anyhow",
  "is-macro",
@@ -1651,20 +1662,19 @@ dependencies = [
 [[package]]
 name = "ruff_index"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "ruff_macros",
 ]
 
 [[package]]
 name = "ruff_linter"
-version = "0.9.3"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+version = "0.11.8"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "aho-corasick",
  "anyhow",
  "bitflags 2.8.0",
- "chrono",
  "colored",
  "fern",
  "glob",
@@ -1673,6 +1683,7 @@ dependencies = [
  "is-macro",
  "is-wsl",
  "itertools 0.14.0",
+ "jiff",
  "libcst",
  "log",
  "memchr",
@@ -1686,7 +1697,6 @@ dependencies = [
  "ruff_annotate_snippets",
  "ruff_cache",
  "ruff_diagnostics",
- "ruff_index",
  "ruff_macros",
  "ruff_notebook",
  "ruff_python_ast",
@@ -1718,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "ruff_macros"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -1730,11 +1740,11 @@ dependencies = [
 [[package]]
 name = "ruff_notebook"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
- "rand",
+ "rand 0.9.2",
  "ruff_diagnostics",
  "ruff_source_file",
  "ruff_text_size",
@@ -1748,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "aho-corasick",
  "bitflags 2.8.0",
@@ -1768,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_codegen"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "ruff_python_ast",
  "ruff_python_literal",
@@ -1780,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_index"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "ruff_python_ast",
  "ruff_python_parser",
@@ -1792,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_literal"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "bitflags 2.8.0",
  "itertools 0.14.0",
@@ -1803,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_parser"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "bitflags 2.8.0",
  "bstr",
@@ -1822,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_semantic"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "bitflags 2.8.0",
  "is-macro",
@@ -1840,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_stdlib"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "bitflags 2.8.0",
  "unicode-ident",
@@ -1849,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "itertools 0.14.0",
  "ruff_source_file",
@@ -1860,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -1870,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.9.3#90589372daf58ec4d314cbd15db8d2ef572c33cc"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.8#75effb8ed7430288648eb616b1499939700edff6"
 dependencies = [
  "serde",
 ]
@@ -2068,12 +2078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,23 +2149,22 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -2436,7 +2439,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2488,7 +2491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom 0.2.15",
- "rand",
+ "rand 0.8.5",
  "uuid-macro-internal",
  "wasm-bindgen",
 ]
@@ -2651,15 +2654,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ bench = false
 pyo3 = { version = "0.26.0", features = ["abi3-py37", "auto-initialize"] }
 regex = "1.11.1"
 once_cell = "1.21.3"
-ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
-ruff_linter = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
-ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.9.3" }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.8" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.8" }
+ruff_linter = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.8" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.8" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.8" }
 cached = { version = "0.54.0", features = ["disk_store"] }
 globset = "0.4.15"
 toml = "0.8.19"

--- a/src/python/parsing.rs
+++ b/src/python/parsing.rs
@@ -13,7 +13,9 @@ pub type Result<T> = std::result::Result<T, ParsingError>;
 
 /// Use the ruff-python-parser crate to parse a Python source file into an AST
 pub fn parse_python_source(python_source: &str) -> Result<Mod> {
-    Ok(parse(python_source, Mode::Module)?.syntax().to_owned())
+    Ok(parse(python_source, Mode::Module.into())?
+        .syntax()
+        .to_owned())
 }
 
 struct InterfaceVisitor {


### PR DESCRIPTION
fixes #28 